### PR TITLE
Load plugin explicitly

### DIFF
--- a/lib/minitest/test_profile.rb
+++ b/lib/minitest/test_profile.rb
@@ -17,3 +17,5 @@ module Minitest
     end
   end
 end
+
+Minitest.load(:test_profile) if Minitest.respond_to?(:load)


### PR DESCRIPTION
minitest doesn't load plugins automatically since v6. This is for to preserve the original behavior.